### PR TITLE
wiseconnect: Fix clock init

### DIFF
--- a/wiseconnect/CMakeLists.txt
+++ b/wiseconnect/CMakeLists.txt
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(
+    ../gecko/common/inc
     components/device/silabs/si91x/mcu/core/config
     components/device/silabs/si91x/mcu/core/chip/inc
     components/device/silabs/si91x/mcu/drivers/rom_driver/inc
     components/device/silabs/si91x/mcu/drivers/peripheral_drivers/inc
+    components/device/silabs/si91x/mcu/drivers/service/clock_manager/inc
     components/device/silabs/si91x/mcu/drivers/systemlevel/inc
     components/device/silabs/si91x/mcu/drivers/cmsis_driver/config
     components/device/silabs/si91x/mcu/drivers/cmsis_driver
@@ -34,6 +36,7 @@ zephyr_sources(
     components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_ipmu.c
     components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_pll.c
     components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_ulpss_clk.c
+    components/device/silabs/si91x/mcu/drivers/service/clock_manager/src/sl_si91x_clock_manager.c
     components/device/silabs/si91x/mcu/core/chip/src/iPMU_prog/iPMU_dotc/ipmu_apis.c
     components/device/silabs/si91x/mcu/core/chip/src/iPMU_prog/iPMU_dotc/rsi_system_config_917.c
 )

--- a/wiseconnect/CMakeLists.txt
+++ b/wiseconnect/CMakeLists.txt
@@ -23,7 +23,13 @@ zephyr_compile_definitions(
     SLI_SI917B0
     CLOCK_ROMDRIVER_PRESENT
 )
+
+zephyr_compile_definitions_ifdef(CONFIG_SIWX917_FLASH_MODE_COMMON
+    SLI_SI91X_MCU_COMMON_FLASH_MODE=1
+)
+
 zephyr_sources(
+    components/device/silabs/si91x/mcu/core/chip/src/rsi_deepsleep_soc.c
     components/device/silabs/si91x/mcu/core/chip/src/system_si91x.c
     components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_ipmu.c
     components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_pll.c

--- a/wiseconnect/components/device/silabs/si91x/mcu/core/chip/src/rsi_deepsleep_soc.c
+++ b/wiseconnect/components/device/silabs/si91x/mcu/core/chip/src/rsi_deepsleep_soc.c
@@ -1,0 +1,694 @@
+/*******************************************************************************
+* @file  rsi_deepsleep_soc.c
+* @brief 
+*******************************************************************************
+* # License
+* <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+*******************************************************************************
+*
+* The licensor of this software is Silicon Laboratories Inc. Your use of this
+* software is governed by the terms of Silicon Labs Master Software License
+* Agreement (MSLA) available at
+* www.silabs.com/about-us/legal/master-software-license-agreement. This
+* software is distributed to you in Source Code format and is governed by the
+* sections of the MSLA applicable to Source Code.
+*
+******************************************************************************/
+
+/**
+ * Includes
+ */
+#include "rsi_ccp_common.h"
+#include "rsi_power_save.h"
+#include "rsi_temp_sensor.h"
+#ifdef DEBUG_UART
+#include "rsi_debug.h"
+#endif
+
+void fpuInit(void);
+#define NWPAON_MEM_HOST_ACCESS_CTRL_CLEAR_1 (*(volatile uint32_t *)(0x41300000 + 0x4))
+#define NWPAON_MEM_HOST_ACCESS_CTRL_SET_1   (*(volatile uint32_t *)(0x41300000 + 0x0))
+#define M4SS_TASS_CTRL_SET_REG              (*(volatile uint32_t *)(0x24048400 + 0x34))
+#define M4SS_TASS_CTRL_CLEAR_REG            (*(volatile uint32_t *)(0x24048400 + 0x38))
+#define M4SS_TASS_CTRL_CLR_REG              (*(volatile uint32_t *)(0x24048400 + 0x38))
+#define MAX_NVIC_REGS                       4   // Max Interrupts register
+#define MAX_IPS                             240 // Max Interrupt Priority registers
+#define MAX_SHP                             12  //Max System Handlers Priority registers
+
+#ifdef SLI_SI91X_MCU_4MB_LITE_IMAGE
+#define MBR_MAGIC_WORD (*(volatile uint32_t *)(0x8160000))
+#else
+#define MBR_MAGIC_WORD (*(volatile uint32_t *)(0x81F0000))
+#endif
+
+#define SL_SCDC_SLEEP  1
+#define SL_SCDC_ACTIVE 0
+
+/* MACRO definition for External LDO Handle, the user must provide the definition for External LDO ON/OFF Handle*/
+#ifndef EXTERNAL_LDO_HANDLE
+/*If User Handle definition is not available keep a Null Definition*/
+#define EXTERNAL_LDO_HANDLE
+#endif
+
+extern void set_scdc(uint32_t Deepsleep);
+
+#ifdef SLI_SI91X_MCU_ENABLE_PSRAM_FEATURE
+#include "sl_si91x_psram_config.h"
+#if PSRAM_HALF_SLEEP_SUPPORTED != FALSE
+extern sl_psram_return_type_t sl_si91x_psram_sleep(void);
+extern sl_psram_return_type_t sl_si91x_psram_wakeup(void);
+#endif
+#endif
+
+uint32_t nvic_enable[MAX_NVIC_REGS] = { 0 };
+uint8_t nvic_ip_reg[MAX_IPS]        = { 0 };
+uint8_t scs_shp_reg[MAX_SHP]        = { 0 };
+volatile uint32_t msp_value, psp_value, control_reg_val;
+
+volatile uint32_t sl_magic_word_value = 0;
+
+#if defined(SLI_SI91X_MCU_ENABLE_RAM_BASED_EXECUTION)
+extern char ram_vector[SI91X_VECTOR_TABLE_ENTRIES];
+#endif
+
+/**
+ * @fn           void RSI_Save_Context(void)
+ * @brief        This function is to save Stack pointer value and Control registers.
+ *
+ */
+void RSI_Save_Context(void)
+{
+  msp_value       = __get_MSP();
+  psp_value       = __get_PSP();
+  control_reg_val = __get_CONTROL();
+}
+/**
+ * @fn           void RSI_Restore_Context(void)
+ * @brief        This function is to Restore Stack pointer value and Control registers.
+ *
+ */
+#ifdef SLI_SI91X_ENABLE_OS
+STATIC INLINE void RSI_Restore_Context(void)
+{
+  __set_CONTROL(control_reg_val);
+  __set_PSP(psp_value);
+  __set_MSP(msp_value);
+}
+#endif
+#if defined(__CC_ARM) /*------------------ARM CC Compiler -----------------*/
+/**
+ * @fn          __asm  void RSI_PS_SaveCpuContext(void)
+ * @brief        This API is used to save the CPU status register into RAM, this API should be used when sleep with RET is required
+ * @return       none
+ */
+__asm void RSI_PS_SaveCpuContext(void)
+{
+  IMPORT __sp;
+  PUSH{ r0 };
+  PUSH{ r1 };
+  PUSH{ r2 };
+  PUSH{ r3 };
+  PUSH{ r4 };
+  PUSH{ r5 };
+  PUSH{ r6 };
+  PUSH{ r7 };
+  PUSH{ r8 };
+  PUSH{ r9 };
+  PUSH{ r10 };
+  PUSH{ r11 };
+  PUSH{ r12 };
+  PUSH{ r14 };
+  LDR r0, = __sp;
+  MRS r1, msp;
+  STR r1, [r0];
+  WFI;
+}
+
+/**
+ * @fn           void RSI_PS_RestoreCpuContext(void)
+ * @brief        This API is used to restore the current CPU processing content from (POP) stack
+ * @return       none
+ */
+__asm void RSI_PS_RestoreCpuContext(void)
+{
+  IMPORT __sp;
+  LDR r0, = __sp;
+  LDR sp, [r0, #0];
+  POP{ r14 };
+  POP{ r12 };
+  POP{ r11 };
+  POP{ r10 };
+  POP{ r9 };
+  POP{ r8 };
+  POP{ r7 };
+  POP{ r6 };
+  POP{ r5 };
+  POP{ r4 };
+  POP{ r3 };
+  POP{ r2 };
+  POP{ r1 };
+  POP{ r0 };
+  BX LR;
+}
+#endif /*------------------ARM CC Compiler -----------------*/
+
+#if defined(__GNUC__) /*------------------ GNU Compiler ---------------------*/
+
+/**
+ * @fn           void RSI_PS_SaveCpuContext(void)
+ * @brief        This API is used to save the CPU status register into RAM, this API should be used when sleep with RET is required
+ * @return       none
+ */
+void RSI_PS_SaveCpuContext(void)
+{
+  __asm("push {r0}");
+  __asm("push {r1}");
+  __asm("push {r2}");
+  __asm("push {r3}");
+  __asm("push {r4}");
+  __asm("push {r5}");
+  __asm("push {r6}");
+  __asm("push {r7}");
+  __asm("push {r8}");
+  __asm("push {r9}");
+  __asm("push {r10}");
+  __asm("push {r11}");
+  __asm("push {r12}");
+  __asm("push {r14}");
+
+  /*R13 Stack pointer */
+  __asm("mov %0, sp\n\t" : "=r"(__sp));
+  __asm("WFI");
+}
+
+/**
+ * @fn           void RSI_PS_RestoreCpuContext(void)
+ * @brief        This API is used to restore the current CPU processing content from (POP) stack
+ * @return       none
+ */
+void RSI_PS_RestoreCpuContext(void)
+{
+  __asm("ldr r0 , =__sp");
+  __asm("ldr sp , [r0 , #0]");
+  __asm("pop {r14}");
+  __asm("pop {r12}");
+  __asm("pop {r11}");
+  __asm("pop {r10}");
+  __asm("pop {r9}");
+  __asm("pop {r8}");
+  __asm("pop {r7}");
+  __asm("pop {r6}");
+  __asm("pop {r5}");
+  __asm("pop {r4}");
+  __asm("pop {r3}");
+  __asm("pop {r2}");
+  __asm("pop {r1}");
+  __asm("pop {r0}");
+}
+#endif /*------------------ GNU Compiler ---------------------*/
+
+#if defined(__ICCARM__) /*------------------ IAR Compiler ---------------------*/
+/**
+ * @fn           void RSI_PS_SaveCpuContext(void)
+ * @brief        This API is used to save the CPU status register into RAM, this API should be used when sleep with RET is required
+ * @return       none
+ */
+void RSI_PS_SaveCpuContext(void)
+{
+  __asm("push {r0}");
+  __asm("push {r1}");
+  __asm("push {r2}");
+  __asm("push {r3}");
+  __asm("push {r4}");
+  __asm("push {r5}");
+  __asm("push {r6}");
+  __asm("push {r7}");
+  __asm("push {r8}");
+  __asm("push {r9}");
+  __asm("push {r10}");
+  __asm("push {r11}");
+  __asm("push {r12}");
+  __asm("push {r14}");
+
+  /*R13 Stack pointer */
+  __asm("mov %0, sp\n\t" : "=r"(__sp));
+  __asm("WFI");
+}
+
+/**
+ * @fn           void RSI_PS_RestoreCpuContext(void)
+ * @brief        This API is used to restore the current CPU processing content from (POP) stack
+ * @return       none
+ */
+void RSI_PS_RestoreCpuContext(void)
+{
+  __asm("ldr r0 , =__sp");
+  __asm("ldr sp , [r0 , #0]");
+  __asm("pop {r14}");
+  __asm("pop {r12}");
+  __asm("pop {r11}");
+  __asm("pop {r10}");
+  __asm("pop {r9}");
+  __asm("pop {r8}");
+  __asm("pop {r7}");
+  __asm("pop {r6}");
+  __asm("pop {r5}");
+  __asm("pop {r4}");
+  __asm("pop {r3}");
+  __asm("pop {r2}");
+  __asm("pop {r1}");
+  __asm("pop {r0}");
+}
+#endif /*------------------ IAR Compiler ---------------------*/
+
+#ifdef SLI_SI91X_MCU_COMMON_FLASH_MODE
+/**
+ * @fn     void RSI_Set_Cntrls_To_M4(void)
+ * @brief  This API is used to set m4ss_ref_clk_mux_ctrl ,tass_ref_clk_mux_ctrl, AON domain power supply controls
+ *         form TA to M4
+ *
+ *
+ * @return none
+ */
+void RSI_Set_Cntrls_To_M4(void)
+{
+  volatile uint8_t delay;
+#ifdef SLI_SI917B0
+  //!take TASS ref clock control to M4
+  MCUAON_CONTROL_REG4 &= ~(MCU_TASS_REF_CLK_SEL_MUX_CTRL);
+#else
+  /* m4ss_ref_clk_mux_ctrl and tass_ref_clk_mux_ctr in M4 Control */
+  NWPAON_MEM_HOST_ACCESS_CTRL_CLEAR_1 = (M4SS_REF_CLK_MUX_CTRL | TASS_REF_CLK_MUX_CTRL);
+#endif
+  /* M4SS controlling Power supply for TASS AON domain */
+  BATT_FF->M4SS_TASS_CTRL_SET_REG_b.M4SS_CTRL_TASS_AON_PWRGATE_EN = ENABLE;
+  /* M4SS controlling Power supply for TASS AON domains isolation enable in bypass mode*/
+  BATT_FF->M4SS_TASS_CTRL_SET_REG_b.M4SS_CTRL_TASS_AON_DISABLE_ISOLATION_BYPASS = ENABLE;
+  /* M4SS controlling Power supply for TASS AON domains reset pin in bypass mode. */
+  M4SS_TASS_CTRL_CLR_REG = M4SS_CTRL_TASS_AON_PWR_DMN_RST_BYPASS_BIT;
+  for (delay = 0; delay < 10; delay++) {
+    __ASM("NOP");
+  }
+}
+/**
+ * @fn     void RSI_Set_Cntrls_To_TA(void)
+ * @brief  This API is used to set m4ss_ref_clk_mux_ctrl ,tass_ref_clk_mux_ctrl ,AON domain power supply controls
+ *         form M4 to TA
+ *
+ *
+ * @return none
+ */
+void RSI_Set_Cntrls_To_TA(void)
+{
+  /* tass_ref_clk_mux_ctr in TA Control */
+  NWPAON_MEM_HOST_ACCESS_CTRL_SET_1 = TASS_REF_CLK_MUX_CTRL;
+}
+#endif
+
+/**
+ * @fn          rsi_error_t RSI_PS_EnterDeepSleep(SLEEP_TYPE_T sleepType , uint8_t lf_clk_mode)
+ * @brief	    This is the common API to keep the system in sleep state. from all possible active states.
+ * @param[in]   sleepType   : selects the retention or non retention mode of processor. refer 'SLEEP_TYPE_T'.
+ *                              SLEEP_WITH_RETENTION : When this is used, user must configure the which RAMs to be retained during sleep by using the 'RSI_PS_SetRamRetention()' function.
+ * @param[in]   lf_clk_mode : This parameter is used to switch the processor clock from high frequency clock to low-frequency clock. This is used in some critical power save cases.
+ *                            0: 'DISABLE_LF_MODE' Normal mode of operation , recommended in most of the applications.
+ *                            1: 'LF_32_KHZ_RC' Processor clock is configured to low-frequency RC clock
+ *                            2: 'LF_32_KHZ_XTAL' Processor clock is configured to low-frequency XTAL clock
+ *                            3: 'EXTERNAL_CAP_MODE' Switches the supply to internal cap mode 0.95V.
+ * @par           note
+ \n User must ensure the selected clocks are active before selecting the 'LF_32_KHZ_RC' and 'LF_32_KHZ_XTAL' clocks to the processor using this API.
+ * @return      Returns the execution status.
+ */
+rsi_error_t RSI_PS_EnterDeepSleep(SLEEP_TYPE_T sleepType, uint8_t lf_clk_mode)
+{
+  volatile int var = 0, enable_sdcss_based_wakeup = 0, enable_m4ulp_retention = 0, Temp;
+  uint32_t ipmuDummyRead = 0, m4ulp_ram_core_status = 0, m4ulp_ram_peri_status = 0, disable_pads_ctrl = 0,
+           ulp_proc_clk         = 0;
+  volatile uint8_t in_ps2_state = 0, x = 0;
+  sl_p2p_intr_status_bkp_t p2p_intr_status_bkp;
+
+  /*Save the NVIC registers */
+  for (var = 0; var < MAX_NVIC_REGS; ++var) {
+    nvic_enable[var] = NVIC->ISER[var];
+  }
+  /* Save the Interrupt Priority Register */
+  for (var = 0; var < MAX_IPS; ++var) {
+    nvic_ip_reg[var] = NVIC->IP[var];
+  }
+  /* Save the System Handlers Priority Registers */
+  for (var = 0; var < MAX_SHP; ++var) {
+    scs_shp_reg[var] = SCB->SHP[var];
+  }
+  /*store the NPSS interrupt mask clear status*/
+  npssIntrState = NPSS_INTR_MASK_CLR_REG;
+
+  /*Clear AUX and DAC pg enables */
+  if (!((MCU_FSM->MCU_FSM_SLEEP_CTRLS_AND_WAKEUP_MODE_b.SDCSS_BASED_WAKEUP_b)
+        || (MCU_FSM->MCU_FSM_SLEEP_CTRLS_AND_WAKEUP_MODE_b.ULPSS_BASED_WAKEUP_b))) {
+    RSI_IPMU_PowerGateClr(AUXDAC_PG_ENB | AUXADC_PG_ENB);
+  }
+  /*Check the PS2 state or not*/
+  if (M4_ULP_SLP_STATUS_REG & ULP_MODE_SWITCHED_NPSS) {
+
+    in_ps2_state = 1U;
+
+    if (!((MCU_FSM->MCU_FSM_SLEEP_CTRLS_AND_WAKEUP_MODE_b.SDCSS_BASED_WAKEUP_b)
+          || (MCU_FSM->MCU_FSM_SLEEP_CTRLS_AND_WAKEUP_MODE_b.ULPSS_BASED_WAKEUP_b))) {
+      disable_pads_ctrl = (ULP_SPI_MEM_MAP(0x141) & BIT(11)); // ULP PADS PDO Status
+      ULP_SPI_MEM_MAP(0x141) &= ~(BIT(11));                   // ULP PADS PDO OFF
+      enable_sdcss_based_wakeup = 1;
+      RSI_PS_SetWkpSources(SDCSS_BASED_WAKEUP);
+    }
+
+    if (!(MCU_FSM->MCU_FSM_SLEEP_CTRLS_AND_WAKEUP_MODE_b.M4ULP_RAM_RETENTION_MODE_EN_b)) {
+      enable_m4ulp_retention = 1;
+      m4ulp_ram_core_status  = RSI_PS_M4ssRamBanksGetPowerSts();
+      m4ulp_ram_peri_status  = RSI_PS_M4ssRamBanksGetPeriPowerSts();
+      RSI_PS_M4ssRamBanksPowerDown(RAM_BANK_7 | RAM_BANK_8 | RAM_BANK_9);
+      RSI_PS_M4ssRamBanksPeriPowerDown(RAM_BANK_7 | RAM_BANK_8 | RAM_BANK_9);
+#ifdef CHIP_9118
+      RSI_PS_SetRamRetention(M4ULP_RAM_RETENTION_MODE_EN);
+#endif
+    }
+  }
+  /*Move to LP mode */
+  RSI_IPMU_RetnLdoLpmode();
+  if (sleepType == SLEEP_WITHOUT_RETENTION) {
+    /*POC1 */
+    RSI_IPMU_PocbiasCurrent();
+    /*RO32K_00_EFUSE. */
+    RSI_IPMU_RO32khzTrim00Efuse();
+    /*RETN1 */
+    RSI_IPMU_RetnLdoLpmode();
+    /*RETN0 */
+    RSI_IPMU_RetnLdoVoltsel();
+  }
+
+  if (!((in_ps2_state) && (MCU_FSM->MCU_FSM_SLEEP_CTRLS_AND_WAKEUP_MODE_b.ULPSS_BASED_WAKEUP_b))) {
+#if (XTAL_CAP_MODE == POWER_TARN_CONDITIONAL_USE)
+    if (lf_clk_mode & BIT(4)) {
+      RSI_PS_NpssPeriPowerUp(SLPSS_PWRGATE_ULP_MCUTS);
+      /*configure the slope,nominal temperature and f2_nominal*/
+      RSI_TS_Config(MCU_TEMP, 25);
+      /*disable the bjt based temp sensor*/
+      RSI_TS_RoBjtEnable(MCU_TEMP, 0);
+      /*Enable the RO based temp sensor*/
+      RSI_TS_Enable(MCU_TEMP, 1);
+      /*update the temperature periodically*/
+      RSI_Periodic_TempUpdate(TIME_PERIOD, 1, 0);
+      /*read the temperature*/
+      Temp = (int)RSI_TS_ReadTemp(MCU_TEMP);
+      if (Temp > 45) {
+        // disable the XTAL CAP mode
+        RSI_IPMU_ProgramConfigData(lp_scdc_extcapmode);
+      }
+    }
+#endif
+
+#if (XTAL_CAP_MODE == POWER_TARN_ALWAYS_USE)
+    // disable the XTAL CAP mode
+    RSI_IPMU_ProgramConfigData(lp_scdc_extcapmode);
+#endif
+  }
+
+  if (!((lf_clk_mode == HF_MHZ_RO))) {
+    /*Clear IPMU BITS*/
+    RSI_PS_LatchCntrlClr(LATCH_TOP_SPI | LATCH_TRANSPARENT_HF | LATCH_TRANSPARENT_LF);
+  }
+
+  ipmuDummyRead = MCU_FSM->MCU_FSM_CLK_ENS_AND_FIRST_BOOTUP;
+
+  /*Update the SCB with Deep sleep BIT */
+  SCB->SCR = 0x4;
+
+  if (in_ps2_state) {
+    /*Read processor clock */
+    ulp_proc_clk = ULPCLK->ULP_TA_CLK_GEN_REG_b.ULP_PROC_CLK_SEL;
+
+    /*LF processor clock configuration */
+    switch (lf_clk_mode & 0x7) {
+      case DISABLE_LF_MODE:
+        /*Do nothing*/
+        break;
+      case LF_32_KHZ_RC:
+        ULPCLK->ULP_TA_CLK_GEN_REG_b.ULP_PROC_CLK_SEL = 2U;
+        break;
+      case LF_32_KHZ_XTAL:
+        ULPCLK->ULP_TA_CLK_GEN_REG_b.ULP_PROC_CLK_SEL = 3U;
+        break;
+      case HF_MHZ_RO:
+        ULPCLK->ULP_TA_CLK_GEN_REG_b.ULP_PROC_CLK_SEL = 5U;
+        break;
+      default:
+        return INVALID_PARAMETERS;
+    }
+    /* HF processor clock */
+  }
+
+  /* Before sleep,Reduce the SCDC voltage by one value */
+  set_scdc(SL_SCDC_SLEEP);
+
+#ifdef SLI_SI91X_MCU_ENABLE_PSRAM_FEATURE
+#if (defined SLI_SI91X_MCU_INTERNAL_LDO_FOR_PSRAM)
+  RSI_PS_M4ssPeriPowerUp(M4SS_PWRGATE_ULP_EFUSE_PERI);
+  if (sleepType == SLEEP_WITH_RETENTION) {
+    //!enable flash LDO and PMU DCDC ON in M4 for PSRAM with retention
+    MCU_FSM_SLEEP_CTRLS_AND_WAKEUP_MODE_REG |= (LDO_FLASH_ON | PMU_DCDC_ON);
+#if PSRAM_HALF_SLEEP_SUPPORTED != FALSE
+    /* Put PSRAM device to sleep */
+    sl_si91x_psram_sleep();
+#endif
+  }
+#elif (defined SLI_SI91X_MCU_EXTERNAL_LDO_FOR_PSRAM)
+#if PSRAM_HALF_SLEEP_SUPPORTED != FALSE
+  if (sleepType == SLEEP_WITH_RETENTION) {
+    /* Put PSRAM device to sleep */
+    sl_si91x_psram_sleep();
+  } else {
+    /* External LDO handle for PSRAM */
+    EXTERNAL_LDO_HANDLE;
+  }
+#endif
+#endif
+#endif
+
+#ifdef SLI_SI91X_ENABLE_OS
+  /* Save Stack pointer value and Control registers */
+  RSI_Save_Context();
+#endif
+  /* Take backup before going to PowerSave */
+  p2p_intr_status_bkp.tass_p2p_intr_mask_clr_bkp = TASS_P2P_INTR_MASK_CLR;
+  p2p_intr_status_bkp.m4ss_p2p_intr_set_reg_bkp  = M4SS_P2P_INTR_SET_REG;
+
+#if ((defined SLI_SI91X_MCU_COMMON_FLASH_MODE) && (!(defined(RAM_COMPILATION))))
+  /* Reset M4_USING_FLASH bit before going to sleep */
+  M4SS_P2P_INTR_CLR_REG = M4_USING_FLASH;
+  /*Before M4 is going to deep sleep , set m4ss_ref_clk_mux_ctrl ,tass_ref_clk_mux_ctr, AON domain power supply controls form M4 to TA */
+#ifdef SLI_SI917B0
+  MCUAON_CONTROL_REG4 |= (MCU_TASS_REF_CLK_SEL_MUX_CTRL);
+  MCUAON_CONTROL_REG4;
+#else
+  NWPAON_MEM_HOST_ACCESS_CTRL_SET_1 = TASS_REF_CLK_MUX_CTRL;
+#endif
+#endif
+  /*Enter sleep with retention*/
+  if (sleepType == SLEEP_WITH_RETENTION) {
+    /*If retention mode is enabled save the CPU context*/
+    RSI_PS_SaveCpuContext();
+  } else {
+    /*Clear RAM retentions*/
+    RSI_PS_ClrRamRetention(M4ULP_RAM16K_RETENTION_MODE_EN | TA_RAM_RETENTION_MODE_EN | M4ULP_RAM_RETENTION_MODE_EN
+                           | M4SS_RAM_RETENTION_MODE_EN);
+    /*do not save CPU context and go to deep sleep */
+    __asm("WFI");
+  }
+
+#ifdef SLI_SI91X_MCU_COMMON_FLASH_MODE
+  /* if flash is not initialised ,then raise a request to TA */
+  if (!(in_ps2_state) && !(M4SS_P2P_INTR_SET_REG & M4_USING_FLASH)) {
+    //!check TA wokeup or not
+    if (!(P2P_STATUS_REG & TA_IS_ACTIVE)) {
+      //!wakeup TA
+      P2P_STATUS_REG |= M4_WAKEUP_TA;
+
+      //!wait for TA active
+      while (!(P2P_STATUS_REG & TA_IS_ACTIVE))
+        ;
+    }
+    //!Check for TA_USING flash bit
+    if (!(TASS_P2P_INTR_CLEAR_REG & TA_USING_FLASH)) {
+      //! Request TA to program flash
+      //! raise an interrupt to TA register
+      M4SS_P2P_INTR_SET_REG = PROGRAM_COMMON_FLASH;
+
+      //!Wait for TA using flash bit
+      while (!(TASS_P2P_INTR_CLEAR_REG & TA_USING_FLASH))
+        ;
+    }
+    M4SS_P2P_INTR_SET_REG = M4_USING_FLASH;
+  }
+#endif
+
+#ifdef SLI_SI91X_MCU_ENABLE_PSRAM_FEATURE
+#if PSRAM_HALF_SLEEP_SUPPORTED != FALSE
+  /* Exit PSRAM device from sleep */
+  sl_si91x_psram_wakeup();
+#endif
+#endif
+
+#ifdef SLI_SI91X_ENABLE_OS
+  /* Restore Stack pointer value and Control registers */
+  RSI_Restore_Context();
+#endif
+  /*Restore the default value to the processor clock */
+  if ((in_ps2_state)) {
+    ULPCLK->ULP_TA_CLK_GEN_REG_b.ULP_PROC_CLK_SEL = (unsigned int)(ulp_proc_clk & 0xF);
+  }
+
+#if ((defined SLI_SI91X_MCU_COMMON_FLASH_MODE) && (!(defined(RAM_COMPILATION))))
+  /* Before TA is going to power save mode, set m4ss_ref_clk_mux_ctrl ,tass_ref_clk_mux_ctrl ,AON domain power supply controls form TA to M4 */
+  RSI_Set_Cntrls_To_M4();
+#endif
+
+// READ_MBR_MAGIC_WORD_ON_WAKEUP
+#ifdef SLI_SI91X_MCU_COMMON_FLASH_MODE
+  if (!(in_ps2_state)) {
+    //!Poll for flash magic word
+    while (MBR_MAGIC_WORD != 0x5A5A) {
+      sl_magic_word_value++;
+    }
+  }
+#endif
+
+#ifndef SL_SI91X_NPSS_GPIO_BTN_HANDLER
+  //NPSS GPIO-2(Button) interrupt clr reg(GPIO_NPSS_INTERRUPT_CLEAR_REG)
+  (*(volatile uint32_t *)(0x12080000UL + 0x08)) = 0x08;
+
+  //NPSS GPIO-2(Button) low-level interrupt enable(GPIO_NPSS_GPIO_CONFIG_REG)
+  (*(volatile uint32_t *)(0x12080000UL + 0x10)) = BIT(18);
+#endif
+  /* After wake-up, Set the SCDC voltage to the actual value*/
+  /* As this function is located in flash accessing this fucntion only after getting controls*/
+  set_scdc(SL_SCDC_ACTIVE);
+
+  /*Update the REG Access SPI division factor to increase the SPI read/write speed*/
+  if (lf_clk_mode == HF_MHZ_RO) {
+    RSI_SetRegSpiDivision(0U);
+  } else {
+    RSI_SetRegSpiDivision(1U);
+  }
+  /*IPMU dummy read to make IPMU block out of RESET*/
+  ipmuDummyRead = ULP_SPI_MEM_MAP(0x144);
+  // After Wakeup
+  if (!((in_ps2_state) && (MCU_FSM->MCU_FSM_SLEEP_CTRLS_AND_WAKEUP_MODE_b.ULPSS_BASED_WAKEUP_b))) {
+#if (XTAL_CAP_MODE == POWER_TARN_CONDITIONAL_USE)
+    if (lf_clk_mode & BIT(4)) {
+      // disable the XTAL CAP mode
+      RSI_PS_NpssPeriPowerUp(SLPSS_PWRGATE_ULP_MCUTS);
+      /*configure the slope,nominal temperature and f2_nominal*/
+      RSI_TS_Config(MCU_TEMP, 25);
+      /*disable the bjt based temp sensor*/
+      RSI_TS_RoBjtEnable(MCU_TEMP, 0);
+      /*Enable the RO based temp sensor*/
+      RSI_TS_Enable(MCU_TEMP, 1);
+      /*update the temperature periodically*/
+      RSI_Periodic_TempUpdate(TIME_PERIOD, 1, 0);
+      /*read the temperature*/
+      Temp = (int)RSI_TS_ReadTemp(MCU_TEMP);
+      if (Temp > 45) {
+        //SCDC0
+        RSI_IPMU_ProgramConfigData(scdc_volt_sel1);
+        RSI_IPMU_ProgramConfigData(scdc_volt_trim_efuse);
+        //SCDC0_1
+        RSI_IPMU_ProgramConfigData(scdc_volt_sel2);
+      }
+    }
+#endif
+
+#if (XTAL_CAP_MODE == POWER_TARN_ALWAYS_USE)
+    // disable the XTAL CAP mode
+    //SCDC0
+    RSI_IPMU_ProgramConfigData(scdc_volt_sel1);
+    RSI_IPMU_ProgramConfigData(scdc_volt_trim_efuse);
+    //SCDC0_1
+    RSI_IPMU_ProgramConfigData(scdc_volt_sel2);
+#endif
+  }
+  if (!(lf_clk_mode == HF_MHZ_RO)) {
+    /*Spare register write sequence*/
+    ipmuDummyRead          = ULP_SPI_MEM_MAP(0x1C1);
+    ULP_SPI_MEM_MAP(0x141) = ipmuDummyRead;
+
+    ipmuDummyRead          = ULP_SPI_MEM_MAP(0x1C0);
+    ULP_SPI_MEM_MAP(0x140) = ipmuDummyRead;
+    RSI_PS_LatchCntrlSet(LATCH_TOP_SPI);
+  }
+  if (in_ps2_state) {
+    /*Come out  of LP  mode */
+    /* enabling the RETN_LDO HP MODE */
+    RSI_IPMU_RetnLdoHpmode();
+  }
+  if (sleepType == SLEEP_WITHOUT_RETENTION) {
+    /* 	Increasing the bias current of RETN_LDO */
+    RSI_IPMU_PocbiasCurrent11();
+    RSI_IPMU_RO32khz_TrimEfuse();
+    /* enabling the RETN_LDO HP MODE */
+    RSI_IPMU_RetnLdoHpmode();
+  }
+  /*I2S-PLL Bypass*/
+  *(volatile uint32_t *)(0x24041400 + 0x3C) |= BIT(0);
+
+  if (enable_sdcss_based_wakeup) {
+    RSI_PS_ClrWkpSources(SDCSS_BASED_WAKEUP);
+    enable_sdcss_based_wakeup = 0;
+  }
+  if (enable_m4ulp_retention) {
+    RSI_PS_M4ssRamBanksPowerUp(m4ulp_ram_core_status);
+    RSI_PS_M4ssRamBanksPeriPowerUp(m4ulp_ram_peri_status);
+    enable_m4ulp_retention = 0;
+  }
+  if (disable_pads_ctrl) {
+    ULP_SPI_MEM_MAP(0x141) |= (BIT(11)); // ULP PADS PDO ON
+    disable_pads_ctrl = 0;
+  }
+  for (x = 0; x < 200; x++) {
+    __ASM("NOP");
+  }
+
+  /* powerup FPU domain*/
+  RSI_PS_M4ssPeriPowerUp(M4SS_PWRGATE_ULP_M4_DEBUG_FPU);
+
+  /*Initialize floating point unit  */
+  fpuInit();
+
+#ifdef DEBUG_UART
+  /*Initialize UART after wake up*/
+  DEBUGINIT();
+#endif
+
+#if defined(SLI_SI91X_MCU_ENABLE_RAM_BASED_EXECUTION)
+  //passing the ram vector address to VTOR register
+  SCB->VTOR = (uint32_t)ram_vector;
+#endif
+
+  /* Restore NPSS INTERRUPTS*/
+  NPSS_INTR_MASK_CLR_REG = ~npssIntrState;
+
+  /* Restore P2P register values from backup */
+  TASS_P2P_INTR_MASK_CLR = ~p2p_intr_status_bkp.tass_p2p_intr_mask_clr_bkp;
+  M4SS_P2P_INTR_SET_REG  = p2p_intr_status_bkp.m4ss_p2p_intr_set_reg_bkp;
+
+  /* Restore the Interrupt Priority Register  */
+  for (var = 0; var < MAX_IPS; ++var) {
+    NVIC->IP[var] = nvic_ip_reg[var];
+  }
+  /* Restore the System Handlers Priority Registers */
+  for (var = 0; var < MAX_SHP; ++var) {
+    SCB->SHP[var] = scs_shp_reg[var];
+  }
+  /* Restore the NVIC registers */
+  for (var = 0; var < MAX_NVIC_REGS; ++var) {
+    NVIC->ISER[var] = nvic_enable[var];
+  }
+  return RSI_OK;
+}

--- a/wiseconnect/components/device/silabs/si91x/mcu/drivers/service/clock_manager/inc/sl_si91x_clock_manager.h
+++ b/wiseconnect/components/device/silabs/si91x/mcu/drivers/service/clock_manager/inc/sl_si91x_clock_manager.h
@@ -1,0 +1,97 @@
+/************************************************************************************
+ * @file sl_si91x_clock_manager.h
+ * @brief Clock Manager Service API implementation
+ ************************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ ************************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ************************************************************************************/
+
+#ifndef SL_CLOCK_MANAGER_H
+#define SL_CLOCK_MANAGER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "sl_status.h"
+#include "rsi_pll.h"
+
+/************************************************************************************
+ * @addtogroup CLOCK-MANAGER Clock Manager
+ * @ingroup SI91X_SERVICE_APIS
+ * @{
+ ************************************************************************************/
+// -----------------------------------------------------------------------------------
+// GLOBAL DEFINES / MACROS
+// -----------------------------------------------------------------------------------
+#define PLL_REF_CLK_VAL_RC_32MHZ ((uint32_t)(32000000)) // PLL reference clock frequency value of RC_32MHZ_CLK
+#define PLL_REF_CLK_VAL_XTAL     ((uint32_t)(40000000)) // PLL reference clock frequency value of XTAL_CLK
+
+// -----------------------------------------------------------------------------------
+// DATA TYPES
+// -----------------------------------------------------------------------------------
+typedef M4_SOC_CLK_SRC_SEL_T sl_si91x_m4_soc_clk_src_sel_t;
+// -----------------------------------------------------------------------------------
+// GLOBAL FUNCTION PROTOTYPES
+// -----------------------------------------------------------------------------------
+/**
+ * @fn	        sl_status_t sl_si91x_clock_manager_m4_set_core_clk(M4_SOC_CLK_SRC_SEL_T clk_source,
+                                                          uint32_t pll_freq)
+ * @brief		    This API is used to configure the m4_soc clock
+ * @param[in]	  pCLK: Pointer to the pll register instance
+ * @param[in]   clk_source: Enum values of different Core source clocks. See #M4_SOC_CLK_SRC_SEL_T and NOTE for more info
+ * @param[in]   pll_freq: M4 Core Frequency value (in MHz) to set 
+ * @param[in]   div_factor: Division value for M4 Core clock
+ * @return 		  returns zero \ref RSI_OK on success, corresponding error code on failure
+ * @note        For using UlpRefClk clksource need to configure M4ssRefClk frequency. For that need to call \ref RSI_CLK_M4ssRefClkConfig Api first
+ *              -  For using SocPllCLK clksource need to configure SocPll frequency. For that need to call \ref RSI_CLK_SetSocPllFreq Api first
+ *							-  For using IntfPllCLK clksource need to configure IntfPll frequency. For that need to call \ref RSI_CLK_SetIntfPllFreq Api first
+ *							-  For using Sleep clksource need to configure Sleep Clock. For that need to call \ref RSI_CLK_SlpClkConfig Api first
+ */
+sl_status_t sl_si91x_clock_manager_m4_set_core_clk(M4_SOC_CLK_SRC_SEL_T clk_source, uint32_t pll_freq);
+
+/**
+ * @fn	        sl_status_t sl_si91x_clock_manager_set_pll_freq(PLL_TYPE_T pll_type, uint32_t pll_freq, uint32_t pll_ref_clk)
+ * @brief		    This API is used to set the selected PLL clock to desired frequency
+ * @param[in]	  pll_type: PLL type to configure
+ * @return 		  returns zero \ref RSI_OK on success, corresponding error code on failure
+ */
+sl_status_t sl_si91x_clock_manager_set_pll_freq(PLL_TYPE_T pll_type, uint32_t pll_freq, uint32_t pll_ref_clk);
+
+/**
+ * @fn	        sl_si91x_m4_soc_clk_src_sel_t sl_si91x_clock_manager_m4_get_core_clk_src_freq(uint32_t *core_clock)
+ * @brief		    This API is used to read the currently active m4_soc clock source and frequency
+ * @param[in]	  core_clock: Pointer to fill core clock frequency
+ * @return 		  returns the currently active core clock source of type sl_si91x_m4_soc_clk_src_sel_t
+ */
+sl_si91x_m4_soc_clk_src_sel_t sl_si91x_clock_manager_m4_get_core_clk_src_freq(uint32_t *core_clock);
+
+/// @} end group CLOCK-MANAGER ******************************************************/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SL_CLOCK_MANAGER_H */

--- a/wiseconnect/components/device/silabs/si91x/mcu/drivers/service/clock_manager/src/sl_si91x_clock_manager.c
+++ b/wiseconnect/components/device/silabs/si91x/mcu/drivers/service/clock_manager/src/sl_si91x_clock_manager.c
@@ -1,0 +1,219 @@
+/************************************************************************************
+ * @file sl_si91x_clock_manager.c
+ * @brief Clock Manager Service API implementation
+ ************************************************************************************
+ * # License
+ * <b>Copyright 2024 Silicon Laboratories Inc. www.silabs.com</b>
+ ************************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ************************************************************************************/
+
+#include "sl_si91x_clock_manager.h"
+#include "rsi_rom_clks.h"
+
+/************************************************************************************
+ *************************  DEFINES / MACROS  ***************************************
+ ************************************************************************************/
+#define MANUAL_LOCK            1    // Manual lock enable
+#define BYPASS_MANUAL_LOCK     1    // Bypass manual lock enable
+#define SOC_PLL_MM_COUNT_LIMIT 0xA4 // Soc pll count limit
+#define DIVISION_FACTOR        0    // Division factor
+#define QSPI_ODD_DIV_ENABLE    0    // Odd division enable for QSPI clock
+#define QSPI_SWALLO_ENABLE     0    // Swallo enable for QSPI clock
+#define QSPI_DIVISION_FACTOR   0    // Division factor for QSPI clock
+/************************************************************************************
+ *************************  LOCAL VARIABLES  ****************************************
+ ************************************************************************************/
+
+/************************************************************************************
+ *************************  LOCAL TYPE DEFINITIONS  *********************************
+ ************************************************************************************/
+
+/************************************************************************************
+ *************************  LOCAL FUNCTION PROTOTYPES  ******************************
+ ************************************************************************************/
+static sl_status_t convert_rsi_to_sl_error_code(rsi_error_t error);
+/************************************************************************************
+ *************************  GLOBAL FUNCTION DEFINITIONS  ****************************
+ ************************************************************************************/
+
+/**
+ * @fn	        sl_status_t sl_si91x_clock_manager_m4_set_core_clk(M4_SOC_CLK_SRC_SEL_T clk_source,
+                                                          uint32_t pll_freq)
+ * @brief		    This API is used to configure the m4_soc clocks
+ * @param[in]   clk_source: Enum values of different Core source clocks. See #M4_SOC_CLK_SRC_SEL_T and NOTE for more info
+ * @param[in]   pll_freq: M4 Core Frequency value (in MHz) to set
+ * @return 		  returns zero \ref RSI_OK on success, corresponding error code on failure
+ * @note        For using UlpRefClk clksource need to configure M4ssRefClk frequency. For that need to call \ref RSI_CLK_M4ssRefClkConfig Api first
+ *              -  For using SocPllCLK clksource need to configure SocPll frequency. For that need to call \ref RSI_CLK_SetSocPllFreq Api first
+ *							-  For using IntfPllCLK clksource need to configure IntfPll frequency. For that need to call \ref RSI_CLK_SetIntfPllFreq Api first
+ *							-  For using Sleep clksource need to configure Sleep Clock. For that need to call \ref RSI_CLK_SlpClkConfig Api first
+ */
+sl_status_t sl_si91x_clock_manager_m4_set_core_clk(M4_SOC_CLK_SRC_SEL_T clk_source, uint32_t pll_freq)
+{
+  M4CLK_Type *pCLK         = M4CLK;
+  uint32_t div_factor      = DIVISION_FACTOR;
+  rsi_error_t error_status = RSI_OK;
+  sl_status_t status;
+
+  // PLL reference clock set to XTAL_CLK by default
+  uint32_t pll_ref_clk = PLL_REF_CLK_VAL_XTAL;
+
+  // Validating for correct Clock Source input
+  if (clk_source > M4_SLEEPCLK) {
+    status = SL_STATUS_INVALID_PARAMETER;
+    return status;
+  }
+
+  // Changing M4SOC clock to M4_ULPREFCLK
+  error_status = RSI_CLK_M4SocClkConfig(pCLK, M4_ULPREFCLK, 0);
+  status       = convert_rsi_to_sl_error_code(error_status);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  if (clk_source == M4_INTFPLLCLK) {
+    // RSI API to set INTF PLL clock frequency
+    error_status = sl_si91x_clock_manager_set_pll_freq(INFT_PLL, pll_freq, pll_ref_clk);
+  } else if (clk_source == M4_SOCPLLCLK) {
+    // RSI API to set SOC PLL clock frequency
+    error_status = sl_si91x_clock_manager_set_pll_freq(SOC_PLL, pll_freq, pll_ref_clk);
+  }
+
+  // The error status is converted to the SL error code
+  status = convert_rsi_to_sl_error_code(error_status);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  // RSI API to set M4 SOC clock is called and the status is converted to the SL error code.
+  error_status = RSI_CLK_M4SocClkConfig(pCLK, clk_source, div_factor);
+  status       = convert_rsi_to_sl_error_code(error_status);
+  if (status != SL_STATUS_OK) {
+    return status;
+  }
+
+  return status;
+}
+
+/**
+ * @fn	        sl_status_t sl_si91x_clock_manager_set_pll_freq(PLL_TYPE_T pll_type, uint32_t pll_freq, uint32_t pll_ref_clk)
+ * @brief		    This API is used to set the selected PLL clock to particular frequency
+ * @param[in]	  pll_type: PLL type to configure
+ * @return 		  returns zero \ref RSI_OK on success, corresponding error code on failure
+ */
+sl_status_t sl_si91x_clock_manager_set_pll_freq(PLL_TYPE_T pll_type, uint32_t pll_freq, uint32_t pll_ref_clk)
+{
+  M4CLK_Type *pCLK         = M4CLK;
+  rsi_error_t error_status = RSI_OK;
+  sl_status_t status;
+
+  switch (pll_type) {
+    case SOC_PLL:
+      // Configure SOC-PLL lock settings before configuring SOC PLL clock
+      RSI_CLK_SocPllLockConfig(MANUAL_LOCK, BYPASS_MANUAL_LOCK, SOC_PLL_MM_COUNT_LIMIT);
+
+      // RSI API to set SOC PLL clock frequency
+      error_status = RSI_CLK_SetSocPllFreq(pCLK, pll_freq, pll_ref_clk);
+      break;
+
+    case INFT_PLL:
+      // RSI API to set INTF PLL clock frequency
+      error_status = RSI_CLK_SetIntfPllFreq(pCLK, pll_freq, pll_ref_clk);
+      break;
+
+    case I2S_PLL:
+      // RSI API to set I2S PLL clock frequency
+      error_status = RSI_CLK_SetI2sPllFreq(pCLK, pll_freq, pll_ref_clk);
+      break;
+
+    default:
+      break;
+  }
+
+  status = convert_rsi_to_sl_error_code(error_status);
+  return status;
+}
+
+/**
+ * @fn	        sl_si91x_m4_soc_clk_src_sel_t sl_si91x_clock_manager_m4_get_core_clk_src_freq(uint32_t *core_clock)
+ * @brief		    This API is used to read the currently active m4_soc clock source and frequency
+ * @param[in]	  core_clock: Pointer to fill core clock frequency
+ * @return 		  returns the currently active core clock source of type sl_si91x_m4_soc_clk_src_sel_t
+ */
+sl_si91x_m4_soc_clk_src_sel_t sl_si91x_clock_manager_m4_get_core_clk_src_freq(uint32_t *core_clock)
+{
+  M4CLK_Type *pCLK = M4CLK;
+  sl_si91x_m4_soc_clk_src_sel_t clk_src;
+
+  // return currently active core clock frequency via the pointer by reference
+  *core_clock = system_clocks.soc_clock;
+
+  // read currently active core clock source
+  clk_src = pCLK->CLK_CONFIG_REG5_b.M4_SOC_CLK_SEL;
+
+  return clk_src;
+}
+/*******************************************************************************
+ * To validate the RSI error code
+ * While calling the RSI APIs, it returns the RSI Error codes.
+ * This function converts the RSI error codes into SL error codes.
+ * It takes argument as RSI error type and returns the SL error type.
+ * It has a single switch statement which is mapped with the SL error code and
+ * after successful conversion it breaks the switch statement.
+ * If the error code is not listed, by default is SL_STATUS_FAIL.
+ ******************************************************************************/
+static sl_status_t convert_rsi_to_sl_error_code(rsi_error_t error)
+{
+  sl_status_t status;
+  switch (error) {
+    case RSI_OK:
+      status = SL_STATUS_OK;
+      break;
+    case INVALID_PARAMETERS:
+      status = SL_STATUS_INVALID_PARAMETER;
+      break;
+    case ERROR_INVALID_INPUT_FREQUENCY:
+      status = SL_STATUS_INVALID_PARAMETER;
+      break;
+    case ERROR_CLOCK_NOT_ENABLED:
+      status = SL_STATUS_NOT_INITIALIZED;
+      break;
+    case INVALID_SAMPLING_RATE:
+      status = SL_STATUS_INVALID_RANGE;
+      break;
+    case INVALID_SAMPLE_LENGTH:
+      status = SL_STATUS_INVALID_COUNT;
+      break;
+    case ERROR_ADC_INVALID_ARG:
+      status = SL_STATUS_INVALID_PARAMETER;
+      break;
+    case ERROR_PS_INVALID_STATE:
+      status = SL_STATUS_INVALID_PARAMETER;
+      break;
+    default:
+      status = SL_STATUS_FAIL;
+      break;
+  }
+  return status;
+}


### PR DESCRIPTION
Add common flash config, which is required to get access to calibration values during init.

Add clock manager to enable core clock to use 180 MHz PLL. Clock manager depends on GSDK/SiSDK sl_status.h, hence the include path into the gecko directory.