### PR TITLE
wiseconnect: Add RNG driver

### DIFF
--- a/wiseconnect/CMakeLists.txt
+++ b/wiseconnect/CMakeLists.txt
@@ -46,6 +46,10 @@ zephyr_sources(
     components/device/silabs/si91x/mcu/core/chip/src/iPMU_prog/iPMU_dotc/rsi_system_config_917.c
 )
 
+zephyr_sources_ifdef(CONFIG_ENTROPY_SILABS_SIWX917
+    components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_rng.c
+)
+
 if(CONFIG_WIFI_SIWX917)
 zephyr_compile_definitions_ifdef(CONFIG_NET_IPV6
     SLI_SI91X_ENABLE_IPV6

--- a/wiseconnect/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_rng.c
+++ b/wiseconnect/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_rng.c
@@ -1,0 +1,74 @@
+/*******************************************************************************
+* @file  rsi_rng.c
+* @brief 
+*******************************************************************************
+* # License
+* <b>Copyright 2022 Silicon Laboratories Inc. www.silabs.com</b>
+*******************************************************************************
+*
+* The licensor of this software is Silicon Laboratories Inc. Your use of this
+* software is governed by the terms of Silicon Labs Master Software License
+* Agreement (MSLA) available at
+* www.silabs.com/about-us/legal/master-software-license-agreement. This
+* software is distributed to you in Source Code format and is governed by the
+* sections of the MSLA applicable to Source Code.
+*
+******************************************************************************/
+
+// Include Files
+
+#include "rsi_rom_rng.h"
+
+/*==============================================*/
+/**
+ * @fn           uint32_t rng_start(HWRNG_Type *pRNG, uint8_t rngMode)     
+ * @brief        This API is used to start the Random Number Generation
+ * @param[in]    pRNG        :   pointer to the control register
+ * @param[in]    rngMode     :   mode of random number generation
+ * @return       return RSI_OK if successful execution
+ */
+uint32_t rng_start(HWRNG_Type *pRNG, uint8_t rngMode)
+{
+  if (rngMode == 0 || rngMode == 1) {
+    if (rngMode == RSI_RNG_TRUE_RANDOM) {
+      pRNG->HWRNG_CTRL_REG_b.HWRNG_RNG_ST = 1;
+    } else {
+      pRNG->HWRNG_CTRL_REG_b.HWRNG_PRBS_ST = 1;
+    }
+  } else {
+    return ERROR_RNG_INVALID_ARG;
+  }
+  return RSI_OK;
+}
+
+/*==============================================*/
+/**
+ * @fn           void rng_stop(HWRNG_Type *pRNG)    
+ * @brief        This API is used to stop the Random Number Generation
+ * @param[in]    pRNG        :   pointer to the control register
+ * @return       none
+ */
+void rng_stop(HWRNG_Type *pRNG)
+{
+  //Disable clock
+  pRNG->HWRNG_CTRL_REG = 0;
+}
+
+/*==============================================*/
+/**
+ * @fn           void rng_get_bytes(HWRNG_Type *pRNG, uint32_t *randomBytes, uint32_t numberOfBytes)      
+ * @brief        This API is used to get the random number bytes
+ * @param[in]    pRNG           :   pointer to the control register
+ * @param[in]    randomBytes    :   random number register
+ * @param[in]    numberOfBytes  :   number of bytes
+ * @return       none
+ */
+void rng_get_bytes(HWRNG_Type *pRNG, uint32_t *randomBytes, uint32_t numberOfBytes)
+{
+  uint32_t i;
+
+  for (i = 0; i < numberOfBytes; i++) {
+    randomBytes[i] = pRNG->HWRNG_RAND_NUM_REG;
+  }
+}
+const ROM_RNG_API_T rng_api = { &rng_start, &rng_stop, &rng_get_bytes };

--- a/wiseconnect/components/device/silabs/si91x/mcu/drivers/rom_driver/inc/rsi_rom_rng.h
+++ b/wiseconnect/components/device/silabs/si91x/mcu/drivers/rom_driver/inc/rsi_rom_rng.h
@@ -1,0 +1,96 @@
+/*******************************************************************************
+* @file  rsi_rom_rng.h
+* @brief 
+*******************************************************************************
+* # License
+* <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+*******************************************************************************
+*
+* The licensor of this software is Silicon Laboratories Inc. Your use of this
+* software is governed by the terms of Silicon Labs Master Software License
+* Agreement (MSLA) available at
+* www.silabs.com/about-us/legal/master-software-license-agreement. This
+* software is distributed to you in Source Code format and is governed by the
+* sections of the MSLA applicable to Source Code.
+*
+******************************************************************************/
+
+#ifndef __RSI_ROM_RNG_H__
+#define __RSI_ROM_RNG_H__
+
+/**
+ * \ingroup   RSI_SPECIFIC_DRIVERS
+ * \defgroup RNG_DRIVERS 
+ *  @{
+ *
+ */
+#include "rsi_ccp_user_config.h"
+#include "rsi_packing.h"
+#if defined(A11_ROM)
+#include "rsi_rom_table_si91x.h"
+#else
+#include "rsi_rom_table_RS1xxxx.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @fn           STATIC INLINE uint32_t  RSI_RNG_Start(HWRNG_Type *pRNG, uint8_t rngMode)
+ * @brief        This API is used to start the Random Number Generation
+ * @param[in]    pRNG		 : Random Number Generator handler
+ * @param[in]    rngMode : mode of the Random Number Generator
+ *               			- \ref RNG_TRUE_RANDOM   - For True RNG
+ *               			- \ref RNG_PSEUDO_RANDOM - For Psudo RNG
+ * @return       returns 0 \ref RSI_OK on success ,non zero on failure
+ *
+ */
+STATIC INLINE uint32_t RSI_RNG_Start(HWRNG_Type *pRNG, uint8_t rngMode)
+{
+#if defined(RNG_ROMDRIVER_PRESENT)
+  return ROMAPI_RNG_API->rng_start(pRNG, rngMode);
+#else
+  return rng_start(pRNG, rngMode);
+#endif
+}
+
+/**
+ * @fn           STATIC INLINE void  RSI_RNG_Stop(HWRNG_Type *pRNG)
+ * @brief        This API is used to stop the Random Number Generation
+ * @param[in]    pRNG  : Random Number Generator handler
+ * @return       none
+ */
+STATIC INLINE void RSI_RNG_Stop(HWRNG_Type *pRNG)
+{
+#if defined(RNG_ROMDRIVER_PRESENT)
+  ROMAPI_RNG_API->rng_stop(pRNG);
+#else
+  rng_stop(pRNG);
+#endif
+}
+
+/**
+ * @fn           STATIC INLINE void  RSI_RNG_GetBytes(HWRNG_Type *pRNG, uint32_t *randomBytes, uint32_t numberOfBytes)
+ * @brief        This API is used to get the random number bytes
+ * @param[in]    pRNG	         : Random Number Generator handler
+ * @param[in]    numberOfBytes : Number of bytes to generate
+ * @param[out]   randomBytes	 : variable or array to store generated random bytes
+ * @return       none
+ */
+STATIC INLINE void RSI_RNG_GetBytes(HWRNG_Type *pRNG, uint32_t *randomBytes, uint32_t numberOfBytes)
+{
+#if defined(RNG_ROMDRIVER_PRESENT)
+  ROMAPI_RNG_API->rng_get_bytes(pRNG, randomBytes, numberOfBytes);
+#else
+  rng_get_bytes(pRNG, randomBytes, numberOfBytes);
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+/* @} end of RSI_RNG_DRIVERS */


### PR DESCRIPTION
Origin: Silicon Labs WiSeConnect SDK
License: MSLA
URL: https://github.com/siliconlabs/wiseconnect
Commit: e97a0ed00ddda347a8a39e8276f470e1c5fea469
Version: 3.3
Purpose: Add Random Number Generator support for SiWx917