### PR TITLE
[cherry-pick] simplicity_sdk: Patch pa_conversions_efr32.c to not conflict

### DIFF
--- a/scripts/patch_simplicity_sdk.sh
+++ b/scripts/patch_simplicity_sdk.sh
@@ -12,5 +12,8 @@ sed -i '' "s/   first/first/" simplicity_sdk/platform/common/inc/sl_common.h
 # Replace legacy Kconfig option name
 sed -i '' "s/CONFIG_SOC_FAMILY_EXX32/__ZEPHYR__/" simplicity_sdk/platform/emlib/inc/em_ramfunc.h
 
+# Rename MAX macro conflicting with Zephyr macro
+sed -i '' "s/MAX(/_SL_MAX(/" simplicity_sdk/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c
+
 # Add Zephyr OS abstraction for crypto
 sed -i '' "s/#\(if defined(SL_CATALOG_MICRIUMOS_KERNEL_PRESENT)\)/#if defined(__ZEPHYR__)\n  #include \"sli_psec_osal_zephyr.h\"\n  #define SLI_PSEC_THREADING\n#el\1/" simplicity_sdk/platform/security/sl_component/sli_psec_osal/inc/sli_psec_osal.h

--- a/simplicity_sdk/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c
+++ b/simplicity_sdk/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c
@@ -43,7 +43,7 @@
 #include "pa_conversions_efr32.h"
 #include "rail.h"
 
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define _SL_MAX(a, b) ((a) > (b) ? (a) : (b))
 
 static RAIL_TxPowerCurvesConfigAlt_t powerCurvesState;
 
@@ -319,7 +319,7 @@ RAIL_TxPowerLevel_t RAIL_ConvertDbmToRaw(RAIL_Handle_t railHandle,
   if ((mode < sizeof(supportedPaIndices))
       && (supportedPaIndices[mode] < RAIL_NUM_PA)) {
     RAIL_PaDescriptor_t const *modeInfo = &powerCurvesState.curves[supportedPaIndices[mode]];
-    uint32_t minPowerLevel = MAX(modeInfo->min, PA_CONVERSION_MINIMUM_PWRLVL);
+    uint32_t minPowerLevel = _SL_MAX(modeInfo->min, PA_CONVERSION_MINIMUM_PWRLVL);
 #if RAIL_SUPPORTS_DBM_POWERSETTING_MAPPING_TABLE
     if (modeInfo->algorithm == RAIL_PA_ALGORITHM_DBM_POWERSETTING_MAPPING_TABLE) {
       RAIL_TxPower_t minPower = modeInfo->minPowerDbm;
@@ -472,7 +472,7 @@ RAIL_TxPower_t RAIL_ConvertRawToDbm(RAIL_Handle_t railHandle,
       }
 
       // We 1-index low power PA power levels, but of course arrays are 0 indexed
-      powerLevel -= MAX(modeInfo->min, PA_CONVERSION_MINIMUM_PWRLVL);
+      powerLevel -= _SL_MAX(modeInfo->min, PA_CONVERSION_MINIMUM_PWRLVL);
 
       //If the index calculation above underflowed, then provide the lowest array index.
       if (powerLevel > (modeInfo->max - modeInfo->min)) {


### PR DESCRIPTION
Zephyr defines the MAX() macro in util.h, which causes a conflict with a locally defined macro of the same name.